### PR TITLE
Set up automated container build and push via GitHub actions

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,0 +1,48 @@
+name: ECR
+
+on:
+  release:
+    types:
+      - published
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - main
+
+jobs:
+  publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      # Hosted at storetheindex AWS account.
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/index-observer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/index-observer:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:alpine AS builder
 
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
+
+WORKDIR /go/src/index-observer
 COPY go.* .
 RUN go mod download
 COPY . .


### PR DESCRIPTION
Set up a mechanism, similar to the one set up already at storetheindex,
that:
- uses an ECR repo dedicated to `index-observer`, managed by
  infrastructure defined in `storetheindex` repo, named
  `index-observer/index-observer` in us-east-2.
- on merge to `main` builds and pushes images with tag format
  `<build-timestamp>-<commit-sha>`
- on release publication builds and pushes images with tag format
  matching the release semver.

Compile the source from a path other than `GOPATH` when building the
container image. Otherwise, the build fails with:
 - `$GOPATH/go.mod exists but should not`.

To fix this, change the working directory during go dependency
resolution and source compile.

See: https://github.com/filecoin-project/storetheindex/pull/459