### PR TITLE
Fix destination path in `Dockerfile` `COPY`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine AS builder
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 
 WORKDIR /go/src/index-observer
-COPY go.* .
+COPY go.* ./
 RUN go mod download
 COPY . .
 RUN go build -o /index-observer


### PR DESCRIPTION
End the path with `/` to keep docker build happy when copying more than
one source file to a destination.