### PR TITLE
Define K8S manifest placeholder while setting up CD pipeline

### DIFF
--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -1,0 +1,2 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
Set up a placeholder for the place that would contain `dev` instance of
`index-observer` while the cluster-level flux manifests are being
configured in `storetheindex` repo.