### PR TITLE
Define K8S manifests for `dev` deployment and automate CD PR creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+deploy
+README.md

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,43 @@
+name: CD
+on:
+  push:
+    branches:
+      - 'cd/dev'
+
+jobs:
+  pull-request:
+    name: Open PR to main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const head = process.env.GITHUB_REF_NAME;
+            const env = head.replace(/cd\//g, '');
+            core.info(`Checking branch '${head}' for automated deployment to '${env}' environment...`);
+            
+            const { repo, owner } = context.repo;
+            try {
+              const result = await github.rest.pulls.create({
+                title: `Deploy latest to \`${env}\` environment`,
+                owner,
+                repo,
+                head,
+                base: 'main',
+                body: `Approve changes and merge this PR to trigger deployment to \`${env}\` environment.`
+              });
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: result.data.number,
+                labels: ['cd', `env:${env}`]
+              });
+            } catch (e) {
+              if (!e.message.includes('A pull request already exists')) {
+                throw e
+              }
+              core.info('Skipped PR creation since it already exists.')
+            }

--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -6,6 +6,7 @@ on:
       - published
   push:
     paths-ignore:
+      - 'deploy'
       - 'README.md'
     branches:
       - main

--- a/deploy/manifests/base/deployment.yaml
+++ b/deploy/manifests/base/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: index-observer
+  namespace: index-observer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: index-observer
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: index-observer
+    spec:
+      containers:
+        - name: index-observer
+          image: index-observer
+          args:
+            - --port 8080
+            - --indexer https://cid.contact
+          ports:
+            - name: metrics
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              port: metrics

--- a/deploy/manifests/base/kustomization.yaml
+++ b/deploy/manifests/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/deploy/manifests/base/service.yaml
+++ b/deploy/manifests/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: index-observer
+  name: index-observer
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+  selector:
+    app: index-observer
+  type: ClusterIP

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -1,2 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources:
+  - ../../base
+  - monitor.yaml
+
+replicas:
+  - name: index-observer
+    count: 1
+
+images:
+  - name: index-observer
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/index-observer/index-observer # {"$imagepolicy": "index-observer:index-observer:name"}
+    newTag: 20220509124752-00177b5b5eb76c5b0e8121a781298225898d58d8 # {"$imagepolicy": "index-observer:index-observer:tag"}

--- a/deploy/manifests/dev/us-east-2/monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: index-observer
+  labels:
+    app: index-observer
+spec:
+  selector:
+    matchLabels:
+      app: index-observer
+  namespaceSelector:
+    matchNames:
+      - index-observer
+  endpoints:
+    - path: /
+      port: metrics


### PR DESCRIPTION
Define base K8S manifests for `index-observer` as a stateless deployment
object and a headless service. Use the base in `dev` overlay and add
enable prometheus metrics scraping from `/` over `metrics` port.

Automate PR creation when image update is detected by flux and changes
are pushed to `cd/dev` branch.

Ignore resources irrelevant to building the container during container
image build by adding `.dockerignore` file.