### PR TITLE
Disable CGO to avoid dynamic linker issues in scratch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/index-observer
 COPY go.* ./
 RUN go mod download
 COPY . .
-RUN go build -o /index-observer
+RUN CGO_ENABLED=0 go build -o /index-observer
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
Running the container otherwise would result in the following error:
`standard_init_linux.go:228: exec user process caused: no such file or directory`

Instead of massaging dynamic linker, disable CGO since it is not used by
index-observer. This has the added benefit of ending up with smaller
container images.