### PR TITLE
differentiate names of metrics

### DIFF
--- a/task/storagemarket.go
+++ b/task/storagemarket.go
@@ -135,8 +135,8 @@ func (m *marketProvider) Track(ctx context.Context, pl *ProviderList) {
 				Help: "Percentage market participants seen",
 			})
 			dealRate := prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: "fil_provider_rate",
-				Help: "Percentage market participants seen",
+				Name: "fil_deal_rate",
+				Help: "Percentage deals seen",
 			})
 
 			providerRate.Set(float64(pn) / float64(pd))

--- a/task/task.go
+++ b/task/task.go
@@ -52,8 +52,11 @@ func startTracking(c *cli.Context, indexer string, pl *ProviderList) error {
 	if err != nil {
 		return err
 	}
-	mp := NewMarketProvider(c.String("filGatewayAddr"), client)
-	go mp.Track(c.Context, pl)
+
+	if c.String("filGatewayAddr") != "" {
+		mp := NewMarketProvider(c.String("filGatewayAddr"), client)
+		go mp.Track(c.Context, pl)
+	}
 
 	ip := &indexProviders{
 		client: client,


### PR DESCRIPTION
I'm not seeing any `fil_provider_rate` metrics being ommited, but also don't see any errors yet. maybe it's that two metrics are being registered with the same name accidentally?