### PR TITLE
Set K8S resources to guarantee minimum available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.18-alpine AS builder
 
 RUN apk update && apk add --no-cache git ca-certificates make build-base && update-ca-certificates
 

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 replicas:
 - name: index-observer
   count: 1
+patchesStrategicMerge:
+- patch.yaml
 images:
 - name: index-observer
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/index-observer/index-observer # {"$imagepolicy": "index-observer:index-observer:name"}

--- a/deploy/manifests/dev/us-east-2/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: index-observer
+  namespace: index-observer
+spec:
+  template:
+    spec:
+      containers:
+        - name: index-observer
+          image: index-observer
+          resources:
+            requests:
+              cpu: "3.5"
+              memory: 10Gi


### PR DESCRIPTION
`index-observer` service gets evicted repeatedly before it gets the chance to report any meaningful metrics. Set a minimum for resources to guarantee some minimum level.

Fixes #42 