### PR TITLE
Reflect changes to metrics path in service monitor

### DIFF
--- a/deploy/manifests/dev/us-east-2/monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/monitor.yaml
@@ -12,5 +12,5 @@ spec:
     matchNames:
       - index-observer
   endpoints:
-    - path: /
+    - path: /metrics
       port: metrics


### PR DESCRIPTION
The metrics endpoint changed from `/` to `/metrics` in earlier changes. Reflect it in K8S manifests.