### PR TITLE
Define a dedicated readiness check endpoint

### DIFF
--- a/deploy/manifests/base/deployment.yaml
+++ b/deploy/manifests/base/deployment.yaml
@@ -27,3 +27,4 @@ spec:
           readinessProbe:
             httpGet:
               port: metrics
+              path: /ready

--- a/task/metrics.go
+++ b/task/metrics.go
@@ -93,6 +93,7 @@ func StartMetrics(c *cli.Context) error {
 	mux.HandleFunc("/debug/pprof/gc", func(w http.ResponseWriter, req *http.Request) {
 		runtime.GC()
 	})
+	mux.HandleFunc("/ready", ready)
 	port := c.String("port")
 	if !strings.Contains(port, ":") {
 		port = ":" + port

--- a/task/ready.go
+++ b/task/ready.go
@@ -1,0 +1,7 @@
+package task
+
+import "net/http"
+
+func ready(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte("OK"))
+}


### PR DESCRIPTION
Instead of GET to root server as readiness check, define a dedicated readiness check endpoint. This avoids readiness check breaking when the handling of root endpoint changes.